### PR TITLE
Configure test server for js and websockets

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,19 +66,15 @@ Global / fileServicePort := {
       .withPort(Port.fromInt(0).get)
       .withHttpApp {
         Kleisli { req =>
-          fileService[IO](FileService.Config(".")).orNotFound.run(req).map { res =>
-            // TODO find out why mime type is not auto-inferred
-            if (req.uri.renderString.endsWith(".js"))
-              res.withHeaders(
-                "Service-Worker-Allowed" -> "/",
-                "Content-Type" -> "text/javascript"
-              )
-            else res
+          val config =
+            FileService.Config[IO](".", mimeTypes = MimeTypes(Map("js" -> MediaType.text.javascript)))
+          fileService[IO](config).orNotFound.run(req).map {
+            _.withHeaders("Service-Worker-Allowed" -> "/")
           }
         }
       }
       .withHttpWebSocketApp { wsb =>
-        HttpRoutes.of[IO] { case Method.GET -> Root => wsb.build(identity) }.orNotFound
+        HttpRoutes.of[IO] { case Method.GET -> Root / "ws" => wsb.build(identity) }.orNotFound
       }
       .build
       .map(_.address.getPort)


### PR DESCRIPTION
Configure the test server to serve JavaScript files with `text/javascript` MIME type and handle WebSocket requests at `/ws`.

The previous implementation had a `TODO` to correctly infer the MIME type for JavaScript files, which this change addresses by explicitly configuring the `FileService`.

---
<a href="https://cursor.com/background-agent?bcId=bc-b09fac25-a634-4f75-8f61-08849bd4fe12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b09fac25-a634-4f75-8f61-08849bd4fe12">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

